### PR TITLE
Add focus option & Use go code to create conformance objects

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,5 +9,8 @@ func main() {
 	client := client.NewClient()
 	client.ClientSet = service.Init()
 
+	cfg := service.InitArgs()
+	service.RunE2E(client.ClientSet, cfg.Focus)
+
 	client.CheckForE2ELogs()
 }

--- a/pkg/client/check.go
+++ b/pkg/client/check.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/dims/k8s-run-e2e/pkg/service"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
@@ -24,7 +25,7 @@ func (c *Client) CheckForE2ELogs() {
 	informerFactory.WaitForCacheSync(wait.NeverStop)
 
 	for {
-		pod, _ := podInformer.Lister().Pods(NAMESPACE).Get(POD_NAME)
+		pod, _ := podInformer.Lister().Pods(service.Namespace).Get(service.PodName)
 		if pod.Status.Phase == v1.PodRunning {
 			c.getLogs()
 			break

--- a/pkg/client/check.go
+++ b/pkg/client/check.go
@@ -3,8 +3,10 @@ package client
 import (
 	"context"
 	"log"
+	"os"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
@@ -21,7 +23,13 @@ func (c *Client) CheckForE2ELogs() {
 	informerFactory.Start(wait.NeverStop)
 	informerFactory.WaitForCacheSync(wait.NeverStop)
 
-	c.getLogs()
+	for {
+		pod, _ := podInformer.Lister().Pods(NAMESPACE).Get(POD_NAME)
+		if pod.Status.Phase == v1.PodRunning {
+			c.getLogs()
+			break
+		}
+	}
 }
 
 func (c *Client) getLogs() {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,11 +6,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-const (
-	NAMESPACE = "conformance"
-	POD_NAME  = "e2e-conformance-test"
-)
-
 var (
 	ctx = context.TODO()
 )

--- a/pkg/client/pod_log.go
+++ b/pkg/client/pod_log.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/dims/k8s-run-e2e/pkg/service"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -15,7 +16,7 @@ func getPodLogs(cancelCtx context.Context, clientset *kubernetes.Clientset) erro
 		Follow: true,
 	}
 
-	req := clientset.CoreV1().Pods(NAMESPACE).GetLogs(POD_NAME, &podLogOpts)
+	req := clientset.CoreV1().Pods(service.Namespace).GetLogs(service.PodName, &podLogOpts)
 	podLogs, err := req.Stream(ctx)
 	if err != nil {
 		return err
@@ -24,15 +25,9 @@ func getPodLogs(cancelCtx context.Context, clientset *kubernetes.Clientset) erro
 
 	reader := bufio.NewScanner(podLogs)
 
-	for {
-		select {
-		case <-cancelCtx.Done():
-			return nil
-		default:
-			for reader.Scan() {
-				line := reader.Text()
-				fmt.Println(line)
-			}
-		}
+	for reader.Scan() {
+		line := reader.Text()
+		fmt.Println(line)
 	}
+	return nil
 }

--- a/pkg/service/args.go
+++ b/pkg/service/args.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"flag"
+	"fmt"
+)
+
+// ArgConfig stores the argument passed when running the program
+type ArgConfig struct {
+	// Output specifies the directory where pod logs will be stored
+	Output string
+
+	// Focus set the E2E_FOCUS env var to run a specific test
+	// e.g. - sig-auth, sig-apps
+	Focus string
+}
+
+func InitArgs() ArgConfig {
+	var cfg ArgConfig
+
+	flag.StringVar(&cfg.Focus, "focus", "Conformance", "focus runs a specific e2e test. e.g. - sig-auth")
+	flag.StringVar(&cfg.Output, "output", "pod_logs", "output lets people get the logs of the pod in a directory")
+
+	flag.Parse()
+
+	fmt.Println(cfg)
+
+	return cfg
+}

--- a/pkg/service/const.go
+++ b/pkg/service/const.go
@@ -1,0 +1,10 @@
+package service
+
+const (
+	containerImage         = "registry.k8s.io/conformance-amd64:v1.25.0"
+	Namespace              = "conformance"
+	PodName                = "e2e-conformance-test"
+	ClusterRoleBindingName = "conformance-serviceaccount-role"
+	ClusterRoleName        = "conformance-serviceaccount"
+	ServiceAccountName     = "conformance-serviceaccount"
+)

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -1,13 +1,25 @@
 package service
 
 import (
+	"context"
 	"log"
 	"os"
 	"path/filepath"
 
+	v1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	container_image = "registry.k8s.io/conformance-amd64:v1.25.0"
+)
+
+var (
+	ctx = context.Background()
 )
 
 // Initializes the kube confif clientset
@@ -32,4 +44,149 @@ func Init() *kubernetes.Clientset {
 	}
 
 	return clientset
+}
+
+func RunE2E(clientset *kubernetes.Clientset) {
+	conformanceNS := v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "conformance",
+		},
+	}
+
+	conformanceSA := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"component": "conformance",
+			},
+			Name:      "conformance-serviceaccount",
+			Namespace: "conformance",
+		},
+	}
+
+	conformanceClusterRole := rbac.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"component": "conformance",
+			},
+			Name: "conformance-serviceaccount",
+		},
+		Rules: []rbac.PolicyRule{
+			{
+				APIGroups: []string{"*"},
+				Resources: []string{"*"},
+				Verbs:     []string{"*"},
+			},
+			{
+				NonResourceURLs: []string{"/metrics", "/logs", "/logs/*"},
+				Verbs:           []string{"get"},
+			},
+		},
+	}
+
+	conformanceClusterRoleBinding := rbac.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"component": "conformance",
+			},
+			Name: "conformance-serviceaccount-role",
+		},
+		RoleRef: rbac.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "conformance-serviceaccount",
+		},
+		Subjects: []rbac.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "conformance-serviceaccount",
+				Namespace: "conformance",
+			},
+		},
+	}
+
+	conformancePod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "e2e-conformance-test",
+			Namespace: "conformance",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            "conformance-container",
+					Image:           container_image,
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Env: []v1.EnvVar{
+						{
+							Name:  "E2E_FOCUS",
+							Value: "", // TODO
+						},
+						{
+							Name:  "E2E_SKIP",
+							Value: "",
+						},
+						{
+							Name:  "E2E_PROVIDER",
+							Value: "skeleton",
+						},
+						{
+							Name:  "E2E_PARALLEL",
+							Value: "false",
+						},
+						{
+							Name:  "E2E_VERBOSITY",
+							Value: "4",
+						},
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "output-volume",
+							MountPath: "/tmp/results",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "output-volume",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/tmp/results",
+						},
+					},
+				},
+			},
+			RestartPolicy:      v1.RestartPolicyNever,
+			ServiceAccountName: "conformance-serviceaccount",
+		},
+	}
+
+	ns, err := clientset.CoreV1().Namespaces().Create(ctx, &conformanceNS, metav1.CreateOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("namespace created %s\n", ns.Name)
+
+	sa, err := clientset.CoreV1().ServiceAccounts(ns.Name).Create(ctx, &conformanceSA, metav1.CreateOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("serviceaccount created %s\n", sa.Name)
+
+	clusterRole, err := clientset.RbacV1().ClusterRoles().Create(ctx, &conformanceClusterRole, metav1.CreateOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("clusterrole created %s\n", clusterRole.Name)
+
+	clusterRoleBinding, err := clientset.RbacV1().ClusterRoleBindings().Create(ctx, &conformanceClusterRoleBinding, metav1.CreateOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("clusterrolebinding created %s\n", clusterRoleBinding.Name)
+
+	pod, err := clientset.CoreV1().Pods(ns.Name).Create(ctx, &conformancePod, metav1.CreateOptions{})
+	if err != nil {
+		log.Fatal(err)
+	}
+	log.Printf("pod created %s\n", pod.Name)
 }

--- a/pkg/service/init.go
+++ b/pkg/service/init.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -46,7 +47,7 @@ func Init() *kubernetes.Clientset {
 	return clientset
 }
 
-func RunE2E(clientset *kubernetes.Clientset) {
+func RunE2E(clientset *kubernetes.Clientset, focus string) {
 	conformanceNS := v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "conformance",
@@ -118,7 +119,7 @@ func RunE2E(clientset *kubernetes.Clientset) {
 					Env: []v1.EnvVar{
 						{
 							Name:  "E2E_FOCUS",
-							Value: "", // TODO
+							Value: fmt.Sprintf("\\[%s\\]", focus),
 						},
 						{
 							Name:  "E2E_SKIP",


### PR DESCRIPTION
Why we need this PR -
- This PR contains code that will take advantage of the `--focus` option that will let people run a specific e2e test.
`./bin/k8s-run-e2e --focus sig-auth`
- This PR has the code that will create exactly the same objects mentioned [here](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/image/conformance-e2e.yaml)
- This PR also has the code that will clean up the objects after getting all the logs.