### PR TITLE
Add `--output` option to store logs in a file specified

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,6 @@ func main() {
 
 	cfg := service.InitArgs()
 	service.RunE2E(client.ClientSet, cfg.Focus)
-
-	client.CheckForE2ELogs()
+	client.CheckForE2ELogs(cfg.Output)
+	service.Cleanup(client.ClientSet)
 }

--- a/pkg/service/args.go
+++ b/pkg/service/args.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"flag"
-	"fmt"
 )
 
 // ArgConfig stores the argument passed when running the program
@@ -22,8 +21,6 @@ func InitArgs() ArgConfig {
 	flag.StringVar(&cfg.Output, "output", "pod_logs", "output lets people get the logs of the pod in a directory")
 
 	flag.Parse()
-
-	fmt.Println(cfg)
 
 	return cfg
 }


### PR DESCRIPTION
What is this PR for -

- Add functions for creating directory and file(pod name).
- Add code that will write the logs in the file.

Other Minor changes -

- Call the `Cleanup` function so that after done with logs it will clear the resources.

Test -
```bash
./bin/k8s-run-e2e --focus sig-auth --output conformance_log
```