### PR TITLE
Add `--image` option for custom conformance container image

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ func main() {
 	client.ClientSet = service.Init()
 
 	cfg := service.InitArgs()
-	service.RunE2E(client.ClientSet, cfg.Focus)
+	service.RunE2E(client.ClientSet, cfg)
 	client.CheckForE2ELogs(cfg.Output)
 	service.Cleanup(client.ClientSet)
 }

--- a/pkg/service/args.go
+++ b/pkg/service/args.go
@@ -15,6 +15,7 @@ type ArgConfig struct {
 
 	// Image let's people use the conformance container image of their own choice
 	// Get the list of images from https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/conformance
+	// default registry.k8s.io/conformance-amd64:v1.25.0
 	Image string
 }
 
@@ -23,7 +24,8 @@ func InitArgs() ArgConfig {
 
 	flag.StringVar(&cfg.Focus, "focus", "Conformance", "focus runs a specific e2e test. e.g. - sig-auth")
 	flag.StringVar(&cfg.Output, "output", "pod_logs", "output lets people get the logs of the pod in a directory")
-	flag.StringVar(&cfg.Image, "image", containerImage, "image let's you select your conformance container image of yoor choice")
+	flag.StringVar(&cfg.Image, "image", containerImage,
+		"image let's you select your conformance container image of your choice. for example, for v1.25.0 version of tests, use - 'registry.k8s.io/conformance-amd64:v1.25.0'")
 
 	flag.Parse()
 

--- a/pkg/service/args.go
+++ b/pkg/service/args.go
@@ -12,6 +12,10 @@ type ArgConfig struct {
 	// Focus set the E2E_FOCUS env var to run a specific test
 	// e.g. - sig-auth, sig-apps
 	Focus string
+
+	// Image let's people use the conformance container image of their own choice
+	// Get the list of images from https://console.cloud.google.com/gcr/images/k8s-artifacts-prod/us/conformance
+	Image string
 }
 
 func InitArgs() ArgConfig {
@@ -19,6 +23,7 @@ func InitArgs() ArgConfig {
 
 	flag.StringVar(&cfg.Focus, "focus", "Conformance", "focus runs a specific e2e test. e.g. - sig-auth")
 	flag.StringVar(&cfg.Output, "output", "pod_logs", "output lets people get the logs of the pod in a directory")
+	flag.StringVar(&cfg.Image, "image", containerImage, "image let's you select your conformance container image of yoor choice")
 
 	flag.Parse()
 


### PR DESCRIPTION
What is this PR for -

- Add the `--image` option to choose a custom conformance container image.

Other Minor changes -

- Add a check to see if the object already exists or not and ignore them while creating.

Test -

```bash
./bin/k8s-run-e2e --focus sig-auth --image registry.k8s.io/conformance-amd64:v1.24.0
```